### PR TITLE
fix travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: ruby
+rvm:
+  - 2.3.3
+
+before_script:
+  - RAILS_ENV=test bundle exec rails db:setup --trace
+
+script:
+  - RAILS_ENV=test bundle exec rspec

--- a/travis.yml
+++ b/travis.yml
@@ -1,6 +1,0 @@
-language: ruby
-rvm:
-  - 2.3.3
-
-before_script:
-  - RAILS_ENV=test bundle exec rake db:setup --trace


### PR DESCRIPTION
- forgot the preceeding `.`
- updates the db:setup to use `rails` instead of `rake` for rails 5